### PR TITLE
Implement basic multiplayer support

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -14,6 +14,7 @@ import uuid
 import sys
 from pydantic import BaseModel
 from fastapi import Request
+from typing import Dict, Optional
 from lyrics_scraper import get_lyrics_by_search
 
 # Arama listesi
@@ -36,8 +37,14 @@ app.add_middleware(
 )
 
 class GuessRequest(BaseModel):
+    player: str
     guess: str
-    answer: str
+
+scoreboard: Dict[str, int] = {}
+current_query: Optional[str] = None
+current_lyrics: Optional[str] = None
+current_snippet: Optional[str] = None
+round_active: bool = False
 
 # Snippet'ları static olarak sun
 app.mount("/snippets", StaticFiles(directory="static/snippets"), name="snippets")
@@ -46,18 +53,26 @@ app.mount("/snippets", StaticFiles(directory="static/snippets"), name="snippets"
 
 @app.get("/api/snippet")
 def get_random_snippet():
+    global current_query, current_snippet, current_lyrics, round_active
+
+    if round_active and current_snippet:
+        return {
+            "query": current_query,
+            "snippet_url": current_snippet,
+            "duration": 12,
+            "lyrics": current_lyrics,
+        }
+
     query = random.choice(search_queries)
     print(f"🎲 Seçilen şarkı: {query}")
 
     try:
         audio_url = get_best_audio_url_from_youtube(query)
 
-        # Snippet oluştur
         filename = f"snippet_{uuid.uuid4()}.mp3"
         output_path = os.path.join("static/snippets", filename)
         generate_snippet_from_url(audio_url, duration=12, output_path=output_path)
 
-        # Şarkı sözlerini çek (artist + title ayrımı için parse etmen gerekebilir)
         if "-" in query:
             title, artist = query.split("-", 1)
         elif " " in query:
@@ -68,11 +83,16 @@ def get_random_snippet():
         lyrics = get_lyrics_by_search(artist.strip(), title.strip())
         print("🎶 Lyrics ilk 200 karakter:", lyrics[:200] if lyrics else "Yok")
 
+        current_query = query
+        current_snippet = f"/snippets/{filename}"
+        current_lyrics = lyrics if lyrics else "Lyrics bulunamadı."
+        round_active = True
+
         return {
-            "query": query,
-            "snippet_url": f"/snippets/{filename}",
+            "query": current_query,
+            "snippet_url": current_snippet,
             "duration": 12,
-            "lyrics": lyrics if lyrics else "Lyrics bulunamadı."
+            "lyrics": current_lyrics,
         }
 
     except Exception as e:
@@ -82,11 +102,27 @@ def get_random_snippet():
 
 @app.post("/api/check")
 def check_guess(data: GuessRequest):
-    guess = data.guess.lower().strip()
-    answer = data.answer.lower().strip()
+    global round_active, scoreboard, current_query
 
-    correct = guess in answer or answer in guess
-    return {"correct": correct}
+    guess = data.guess.lower().strip()
+    player = data.player
+
+    if player not in scoreboard:
+        scoreboard[player] = 0
+
+    correct = False
+    winner = None
+
+    if current_query:
+        answer = current_query.lower()
+        if guess in answer or answer in guess:
+            correct = True
+            if round_active:
+                scoreboard[player] += 1
+                winner = player
+                round_active = False
+
+    return {"correct": correct, "winner": winner, "scoreboard": scoreboard}
 
 app.mount(
     "/", 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
   <h1>🎶 Guess the Song!</h1>
+  <div id="player-info"></div>
   
   <div id="snippet-container">
     <audio id="audio-player" controls></audio>
@@ -23,6 +24,11 @@
   <h3>Lyrics:</h3>
   <p id="lyrics">Yükleniyor...</p>
 </div>
+
+  <div id="scoreboard">
+    <h3>Scoreboard</h3>
+    <div id="scores"></div>
+  </div>
 
 
   <script src="/script.js"></script>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,4 +1,5 @@
 let currentQuery = ""; // Sunucudan gelen gerçek şarkı adı (gizli tutulacak)
+let playerName = "";
 
 console.log("✅ script.js loaded");
 
@@ -36,17 +37,23 @@ function submitGuess() {
       "Content-Type": "application/json"
     },
     body: JSON.stringify({
-      guess: userGuess,
-      answer: currentQuery
+      player: playerName,
+      guess: userGuess
     })
   })
     .then(res => res.json())
     .then(data => {
       if (data.correct) {
-        resultText.textContent = "✅ Doğru tahmin!";
+        if (data.winner) {
+          resultText.textContent = `✅ Doğru! ${data.winner} kazandı!`;
+          fetchSnippet();
+        } else {
+          resultText.textContent = "✅ Doğru!";
+        }
       } else {
         resultText.textContent = "❌ Yanlış. Tekrar dene!";
       }
+      updateScoreboard(data.scoreboard);
     })
     .catch(err => {
       console.error("❌ Tahmin kontrol hatası:", err);
@@ -54,8 +61,20 @@ function submitGuess() {
     });
 }
 
-// Sayfa yüklendiğinde ilk snippet gelsin
+function updateScoreboard(scores) {
+  const scoresDiv = document.getElementById("scores");
+  scoresDiv.innerHTML = "";
+  for (const player in scores) {
+    const p = document.createElement("p");
+    p.textContent = `${player}: ${scores[player]}`;
+    scoresDiv.appendChild(p);
+  }
+}
+
+// Sayfa yüklendiğinde oyuncu adı istenip snippet gelsin
 window.addEventListener("DOMContentLoaded", () => {
-  console.log("🎶 Sayfa yüklendi, snippet çekiliyor...");
+  playerName = prompt("Adınızı girin:") || `Player-${Math.floor(Math.random()*1000)}`;
+  const infoDiv = document.getElementById("player-info");
+  infoDiv.textContent = `Oyuncu: ${playerName}`;
   fetchSnippet();
 });

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -23,4 +23,12 @@ body {
     margin-top: 20px;
     font-weight: bold;
   }
+
+#scoreboard {
+  margin-top: 30px;
+}
+
+#scoreboard p {
+  margin: 5px 0;
+}
   


### PR DESCRIPTION
## Summary
- support multiplayer state in backend with scoreboard
- show scoreboard and prompt for player name in UI
- track player guesses and update scores

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6871829f95188328bd914d0147166a89